### PR TITLE
Do not index fields with invalid characters

### DIFF
--- a/apps/firehose_to_es_processor/lib/firehose_record.py
+++ b/apps/firehose_to_es_processor/lib/firehose_record.py
@@ -1,9 +1,12 @@
 import json
+import re
 from datetime import datetime
 from lib.util import extract_json
 
 
 class FirehoseRecord:
+
+    invalid_chars = re.compile("[\s\"*<|,>/?\\\]")
 
     def __init__(self, record):
         self.record = record
@@ -36,6 +39,7 @@ class FirehoseRecord:
         transformed_message = extract_json(log_event["message"])
         if transformed_message and type(transformed_message) == dict:
             for k, v in transformed_message.items():
-                transformed_payload[k] = json.dumps(v)
+                if FirehoseRecord.invalid_chars.search(k) is None:
+                    transformed_payload[k] = json.dumps(v)
 
         return transformed_payload

--- a/apps/firehose_to_es_processor/test/test_firehose_record.py
+++ b/apps/firehose_to_es_processor/test/test_firehose_record.py
@@ -6,8 +6,8 @@ class TestFirehoseRecord(unittest.TestCase):
 
     data = {"owner": "test_owner", "logGroup": "/test/test_log_group", "logStream": "test_log_stream",
             "messageType": 'DATA_MESSAGE'}
-    data["logEvents"] = [{"id": 123456, "timestamp": 1519970297000, "message": 'with_json{"hi": "hello"}with_json'},
-                         {"id": 123456, "timestamp": 1519970297000, "message": 'with_json{"hi": "hello"}with_json'}]
+    data["logEvents"] = [{"id": 123456, "timestamp": 1519970297000, "message": 'with_json{"hi": "hello", "invalid?": "yes"}with_json'},
+                         {"id": 123456, "timestamp": 1519970297000, "message": 'with_json{"hi": "hello", "invalid?": "yes"}with_json'}]
     firehose_record = FirehoseRecord(data)
 
     def test_transform_and_extract_from_log_event(self):
@@ -18,7 +18,8 @@ class TestFirehoseRecord(unittest.TestCase):
         log_event_one = transformed_log_events[0]
         self.assertEqual(log_event_one["@log_group"], "/test/test_log_group")
         self.assertEqual(log_event_one["@log_stream"], "test_log_stream")
-        self.assertEqual(log_event_one["@message"], 'with_json{"hi": "hello"}with_json')
+        self.assertEqual(log_event_one["@message"], 'with_json{"hi": "hello", "invalid?": "yes"}with_json')
         self.assertEqual(log_event_one["@owner"], "test_owner")
         self.assertEqual(log_event_one["@id"], 123456)
         self.assertEqual(log_event_one["hi"], '"hello"')
+        self.assertIsNone(log_event_one.get('invalid?'))


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-net/issues/1426

Without validation, JSON keys with invalid characters will be sent to
elasticsearch as indexable fields. This commit fixes this issue.