### PR TITLE
Subscriber should not fail if the log group does not exist

### DIFF
--- a/apps/cwl_firehose_subscriber/app.py
+++ b/apps/cwl_firehose_subscriber/app.py
@@ -2,16 +2,18 @@ import boto3
 import re
 import os
 
-blacklisted_log_group_names = os.environ["BLACKLISTED_LOG_GROUPS"]
+logs_client = boto3.client('logs')
 
 
-def is_log_group_name_blacklisted(log_group_name, blacklisted_names=blacklisted_log_group_names):
-    blacklisted = False
-    regex_string = "|".join(blacklisted_names.split())
-    regexp = re.compile(regex_string, re.IGNORECASE)
-    if regexp.search(log_group_name):
-        blacklisted = True
-    return blacklisted
+class PrefixSet:
+    def __init__(self, string_list):
+        self.regexp = re.compile("^(?:" + "|".join(string_list) + ")", re.IGNORECASE)
+
+    def matches(self, search_str):
+        return self.regexp.search(search_str) is not None
+
+
+blacklisted_log_groups = PrefixSet(os.environ["BLACKLISTED_LOG_GROUPS"].split())
 
 
 def put_subscription_filter(log_group_name, destination_arn, role_arn):
@@ -28,12 +30,11 @@ def put_subscription_filter(log_group_name, destination_arn, role_arn):
 def handler(event, context):
     """Main Lambda function
     """
-    logs_client = boto3.client('logs')
     log_group_name = event['detail']['requestParameters']['logGroupName']
     account_id = context.invoked_function_arn.split(":")[4]
     delivery_stream_arn = "arn:aws:firehose:us-east-1:{0}:deliverystream/Kinesis-Firehose-ELK".format(account_id)
     cwl_to_kinesis_role_arn = "arn:aws:iam::{0}:role/cwl-firehose".format(account_id)
-    if not is_log_group_name_blacklisted(log_group_name):
+    if not blacklisted_log_groups.matches(log_group_name):
         print("Subscribing log group {0} to firehose".format(log_group_name))
         put_subscription_filter(log_group_name, delivery_stream_arn, cwl_to_kinesis_role_arn)
     else:

--- a/apps/cwl_firehose_subscriber/test/test_app.py
+++ b/apps/cwl_firehose_subscriber/test/test_app.py
@@ -56,5 +56,8 @@ class TestApp(unittest.TestCase):
             filter_name = filters['subscriptionFilters'][0]['filterName']
             self.assertEqual(filter_name, 'firehose')
 
+            # it should not fail if the log group does not exist
+            app.put_subscription_filter('fake-' + str(uuid.uuid4()), delivery_stream_arn, cwl_to_kinesis_role_arn)
+
         finally:
             logs_client.delete_log_group(logGroupName=log_group_name)

--- a/config/blacklisted_log_groups
+++ b/config/blacklisted_log_groups
@@ -1,4 +1,5 @@
 subscribertest
+test-log-group
 /aws/lambda/test_log_group
 /aws/lambda/Firehose-CWL-Processor
 /aws/kinesisfirehose/Kinesis-Firehose-ES


### PR DESCRIPTION
This PR handles the case that the log group was deleted before the subscription could be submitted.