### PR TITLE
Modify index analyzer to handle bundle uuids

### DIFF
--- a/apps/firehose_to_es_processor/lib/es_client.py
+++ b/apps/firehose_to_es_processor/lib/es_client.py
@@ -42,7 +42,20 @@ class ESClient:
         request_body = {
             "settings": {
                 "number_of_shards": 2,
-                "number_of_replicas": 0
+                "number_of_replicas": 0,
+                "analysis": {
+                    "analyzer": {
+                        "default": {
+                            "tokenizer": "bundle_id_tokenizer",
+                        }
+                    },
+                    "tokenizer": {
+                        "bundle_id_tokenizer": {
+                            "type": "pattern",
+                            "pattern": "[\s,{}\[\]\";'+=%^$!~`|\\/?&]+|[.](?![0-9]{6,6}Z)"
+                        }
+                    }
+                }
             }
         }
         index_name = self._format_today_index_name(prefix)


### PR DESCRIPTION
The standard ES tokenizer splits on dashes but not periods. This causes
bundle UUIDs to be split in inconvenient ways as shown below.

`7ef8966b-45ef-4e0a-a51b-44a865372050.2018-06-08T230333.785338Z` becomes
the following tokens
```
7ef8966b
45ef
4e0a
a51b
44a865372050.2018
06
08T230333.785338Z
```
The new tokenizer introduced here splits it into more useful tokens
```
7ef8966b-45ef-4e0a-a51b-44a865372050
2018-06-08T230333.785338Z
```
There are a few consequences of this.

- Querying for the bundle UUID alone will now give you an exact token match.
- Querying for a bunlde version (ISO8601 timestamp) will return exact token match for the version.
- Querying for a bundle FQID (UUID+Version) will return matches for both the UUID and Version. To limit to the specific bundle, users will have to use an 'AND' operator.