### PR TITLE
cloudwatch alerts sent to team specific channels

### DIFF
--- a/apps/cwl_to_slack/app.py
+++ b/apps/cwl_to_slack/app.py
@@ -29,12 +29,10 @@ def handler(event, context):
             "color": color
         }]
 
-    try:
-        slack_channel = json.loads(alert_message['AlarmDescription'])['slack_channel']
-    except:
-        slack_channel = "dcp-ops-alerts"
-
-    slack_url = json.loads(get_secret()['SecretString'])['slack_webhooks'][slack_channel]
+    secrets = json.loads(get_secret()['SecretString'])
+    default_slack_channel = secrets['slack_alert_channel']
+    slack_channel = json.loads(alert_message['AlarmDescription']).get("slack_channel", default_slack_channel)
+    slack_url = secrets['slack_webhooks'][slack_channel]
 
     post_message_to_url(slack_url, {"attachments": attachments})
 

--- a/apps/cwl_to_slack/test/test_app.py
+++ b/apps/cwl_to_slack/test/test_app.py
@@ -1,9 +1,66 @@
 import unittest
+from unittest.mock import patch
+from app import handler
 
 
 class TestApp(unittest.TestCase):
-    def test_fake(self):
-        pass
+    def setUp(self):
+        self.mock_secrets = {
+            'SecretString': '{'
+                            '"slack_webhooks":{'
+                                '"dcp-ops":"dcp_slack_url",'
+                                '"upload-service":"upload_slack_url",'
+                                '"dcp-ops-alerts":"dcp_ops_alert_slack_url"'
+                            '}}'
 
-    def test_more_fake(self):
-        pass
+        }
+
+        self.mock_event_alarm = {
+            'Records': [
+                {
+                    'Sns': {
+                        'Message':
+                            '{"AlarmName":"upload-staging",'
+                            '"AlarmDescription":'
+                                '"{ \\"slack_channel\\": \\"upload-service\\"}",'
+                            '"NewStateValue":"ALARM",'
+                            '"NewStateReason":"words words words",'
+                            '"OldStateValue":"OK"'
+                            '}'
+                    }
+                }
+            ]
+        }
+        self.mock_event_no_channel_ok = {
+            'Records': [
+                {
+                    'Sns': {
+                        'Message':
+                            '{"AlarmName":"upload-staging",'
+                            '"AlarmDescription":'
+                            '"{}",'
+                            '"NewStateValue":"OK",'
+                            '"NewStateReason":"words words words",'
+                            '"OldStateValue":"ALARM"'
+                            '}'
+                    }
+                }
+            ]
+        }
+
+        self.mock_attachment_alarm = {'attachments': [{'fallback': '<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=upload-staging|upload-staging> State is now ALARM: \n words words words', 'title': 'upload-staging', 'title_link': 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=upload-staging', 'text': 'State is now ALARM: \n words words words', 'color': 'danger'}]}
+        self.mock_attachment_ok = {'attachments': [{'fallback': '<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=upload-staging|upload-staging> State is now OK: \n words words words', 'title': 'upload-staging', 'title_link': 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=upload-staging', 'text': 'State is now OK: \n words words words', 'color': 'good'}]}
+
+    @patch('app.get_secret')
+    @patch('app.post_message_to_url')
+    def test_posts_alarm_to_correct_slack_channel(self, mock_post_req, mock_get_secret):
+        mock_get_secret.return_value = self.mock_secrets
+        handler(self.mock_event_alarm, 'no_context')
+        mock_post_req.assert_called_with('upload_slack_url', self.mock_attachment_alarm)
+
+    @patch('app.get_secret')
+    @patch('app.post_message_to_url')
+    def test_posts_to_dcp_ops_alert_if_channel_not_specified(self, mock_post_req, mock_get_secret):
+        mock_get_secret.return_value = self.mock_secrets
+        handler(self.mock_event_no_channel_ok, 'no_context')
+        mock_post_req.assert_called_with('dcp_ops_alert_slack_url', self.mock_attachment_ok)

--- a/apps/cwl_to_slack/test/test_app.py
+++ b/apps/cwl_to_slack/test/test_app.py
@@ -7,6 +7,7 @@ class TestApp(unittest.TestCase):
     def setUp(self):
         self.mock_secrets = {
             'SecretString': '{'
+                            '"slack_alert_channel": "dcp-ops-alerts",'
                             '"slack_webhooks":{'
                                 '"dcp-ops":"dcp_slack_url",'
                                 '"upload-service":"upload_slack_url",'
@@ -48,8 +49,29 @@ class TestApp(unittest.TestCase):
             ]
         }
 
-        self.mock_attachment_alarm = {'attachments': [{'fallback': '<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=upload-staging|upload-staging> State is now ALARM: \n words words words', 'title': 'upload-staging', 'title_link': 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=upload-staging', 'text': 'State is now ALARM: \n words words words', 'color': 'danger'}]}
-        self.mock_attachment_ok = {'attachments': [{'fallback': '<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=upload-staging|upload-staging> State is now OK: \n words words words', 'title': 'upload-staging', 'title_link': 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=upload-staging', 'text': 'State is now OK: \n words words words', 'color': 'good'}]}
+        self.mock_attachment_alarm = {
+            'attachments': [
+                {'fallback': '<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;'
+                             'name=upload-staging|upload-staging> State is now ALARM: \n words words words',
+                 'title': 'upload-staging',
+                 'title_link': 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;'
+                               'name=upload-staging',
+                 'text': 'State is now ALARM: \n words words words',
+                 'color': 'danger'}
+            ]
+        }
+        self.mock_attachment_ok = {
+            'attachments': [
+                {'fallback': '<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;'
+                             'name=upload-staging|upload-staging> State is now OK: \n words words words',
+                 'title': 'upload-staging',
+                 'title_link': 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter'
+                               '=ANY;name=upload-staging',
+                 'text': 'State is now OK: \n words words words',
+                 'color': 'good'
+                 }
+            ]
+        }
 
     @patch('app.get_secret')
     @patch('app.post_message_to_url')


### PR DESCRIPTION
# Need
* cloud watch alerts sent to team specific channels

# Approach
* Create a slack app with channel specific webhooks stored in aws secrets manager determined by slack_channel set in event used to invoke the lambda function

# Tests
* unit tests
* created a test slack channel to test integration and formatting

# ToDo
- [ ] test alert in each slack channel after merging?