### PR TITLE
Handle the case where log group creation fails

### DIFF
--- a/apps/cwl_firehose_subscriber/app.py
+++ b/apps/cwl_firehose_subscriber/app.py
@@ -43,6 +43,9 @@ def handler(event, context):
     """Main Lambda function
     """
     try:
+        if 'errorCode' in event['detail']:
+            logger.info('Creation of log group failed. No operation necessary.')
+            return
         log_group_name = event['detail']['requestParameters']['logGroupName']
         account_id = context.invoked_function_arn.split(":")[4]
         delivery_stream_arn = "arn:aws:firehose:us-east-1:{0}:deliverystream/Kinesis-Firehose-ELK".format(account_id)

--- a/apps/cwl_firehose_subscriber/main.tf
+++ b/apps/cwl_firehose_subscriber/main.tf
@@ -55,12 +55,21 @@ resource "aws_iam_role_policy" "cwl_firehose_subscriber" {
         {
             "Effect": "Allow",
             "Action": [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-                "logs:PutSubscriptionFilter",
-                "logs:CreateLogGroup"
+                "logs:PutSubscriptionFilter"
             ],
             "Resource": "arn:aws:logs:*:*:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:CreateLogGroup"
+            ],
+            "Resource": [
+                "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.cwl_firehose_subscriber.function_name}:*:*",
+                "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.cwl_firehose_subscriber.function_name}"
+            ]
         },
         {
             "Effect": "Allow",


### PR DESCRIPTION
Fixes https://github.com/HumanCellAtlas/logs/issues/60

Log group creation events are sent out even when the creation of the log
group fails. To handle this event, here we check for an 'errorCode'
field in the event and, if it's there, perform a noop.