### PR TITLE
Add CreateLogGroup permissions to retention policy enforcer

### DIFF
--- a/apps/log_retention_policy_enforcer/main.tf
+++ b/apps/log_retention_policy_enforcer/main.tf
@@ -53,6 +53,7 @@ resource "aws_iam_role_policy" "log_retenion_policy_enforcer" {
         {
           "Effect": "Allow",
             "Action": [
+                "logs:CreateLogGroup",
                 "logs:CreateLogStream",
                 "logs:DescribeLogStreams",
                 "logs:PutLogEvents"


### PR DESCRIPTION
Lambda needs this in order to send logs to CloudWatch Logs.